### PR TITLE
Using the ServerTest class name instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/src/Gene.php
+++ b/src/Gene.php
@@ -21,6 +21,6 @@ interface Gene
     public function express(
         OperatingSystem $local,
         Server $target,
-        History $History
+        History $history
     ): History;
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -10,7 +10,7 @@ use Innmind\Server\Control\{
 };
 use PHPUnit\Framework\TestCase;
 
-class RemoteServerTest extends TestCase
+class ServerTest extends TestCase
 {
     public function testInterface()
     {


### PR DESCRIPTION
# Changed log

- Using the `pull_request` trigger on GitHub action to make upcoming contributions running CI automatically.
- The PHP file name should be same as class name and the `RemoteServerTest` class name should change into `ServerTest` class name.
- Fix parameter mismatching via `Psalm` static code analysis. And the `Psalm` report following static code analysis issues:

```Bash
ERROR: ParamNameMismatch - src/Gene/Composer.php:30:17 - Argument 3 of Innmind\Genome\Gene\Composer::express has wrong name $history, expecting $History as defined by Innmind\Genome\Gene::express (see https://psalm.dev/230)
        History $history


ERROR: ParamNameMismatch - src/Gene/ComposerPackage.php:42:17 - Argument 3 of Innmind\Genome\Gene\ComposerPackage::express has wrong name $history, expecting $History as defined by Innmind\Genome\Gene::express (see https://psalm.dev/230)
        History $history


ERROR: ParamNameMismatch - src/Gene/PHP.php:40:17 - Argument 3 of Innmind\Genome\Gene\PHP::express has wrong name $history, expecting $History as defined by Innmind\Genome\Gene::express (see https://psalm.dev/230)
        History $history
```